### PR TITLE
Update: added distance factor for the DS pipeline

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -300,7 +300,7 @@ Change global loudness. Send float value. Volume of individual players is not af
 
     /pyBinSimLoudness {loudness: float32}
 
-Apply a distance factor to the DS component. Send float value.::
+Apply a distance factor to the DS component. Send float value. Volume of individual players is not affected.::
 
     /pyBinSimLoudness {loudness: float32}
 

--- a/README.rst
+++ b/README.rst
@@ -248,12 +248,17 @@ When you want to apply a late filter::
 When you want to play another sound file you send::
 
     ZMQ:    ['/pyBinSimFile', 'folder/file_new.wav']
-    OSC:    /pyBinSimFile 'folder/file_new.wav']
+    OSC:    /pyBinSimFile 'folder/file_new.wav'
 
 If you want to play a sound file list::
 
     ZMQ:    ['/pyBinSimFile', 'folder/file_1.wav#folder/file_2.wav']
-    OSC:    /pyBinSimFile 'folder/file_1.wav#folder/file_2.wav']
+    OSC:    /pyBinSimFile 'folder/file_1.wav#folder/file_2.wav'
+
+If you want to apply a distance factor to the direct sound::
+
+    ZMQ:    ['/pyBinSimDistance', 1.0]
+    OSC:    /pyBinSimDistance 1.0
 
 The audiofile has to be located on the pc where pyBinSim runs. Files are not transmitted over network.
 
@@ -292,6 +297,10 @@ Bypass convolution. Send 'True' or 'False' (as string, not bool)::
     /pybinsimPauseConvolution {pauseConvolution: string["True"|"False"]}
 
 Change global loudness. Send float value. Volume of individual players is not affected.::
+
+    /pyBinSimLoudness {loudness: float32}
+
+Apply a distance factor to the DS component. Send float value.::
 
     /pyBinSimLoudness {loudness: float32}
 

--- a/README.rst
+++ b/README.rst
@@ -302,7 +302,7 @@ Change global loudness. Send float value. Volume of individual players is not af
 
 Apply a distance factor to the DS component. Send float value. Volume of individual players is not affected.::
 
-    /pyBinSimLoudness {loudness: float32}
+    /pyBinSimDistance {distance: float32}
 
 Create a new player. Players can play back files independent from each other. A
 player's output is sent to the start channel and consecutive channels, up to the

--- a/pybinsim/application.py
+++ b/pybinsim/application.py
@@ -59,6 +59,7 @@ class BinSimConfig(object):
                                   'useHeadphoneFilter': False,
                                   'headphone_filterSize': 1024,
                                   'loudnessFactor': float(1),
+                                  'distanceFactor': float(1),
                                   'maxChannels': 8,
                                   'samplingRate': 48000,
                                   'loopSound': True,
@@ -297,6 +298,8 @@ def audio_callback(binsim):
         #binsim.current_config = binsim.oscReceiver.get_current_config()
         binsim.current_config = binsim.pkgReceiver.get_current_config()
 
+        distance = binsim.current_config.get('distanceFactor')
+
         amount_channels = binsim.current_config.get('maxChannels')
         if amount_channels == 0:
             return
@@ -363,7 +366,10 @@ def audio_callback(binsim):
             if callback.config.get('sd_convolverActive'):
                 sd_buffer = binsim.input_BufferSD.process(ds[:,0,:])
                 ds = binsim.sd_convolver.process(sd_buffer) # let's keep the name "ds" for now
-                 
+
+            # apply distance factor to ds block
+            ds *= distance
+
             early = binsim.early_convolver.process(input_buffers)
             late = binsim.late_convolver.process(input_buffers)
 

--- a/pybinsim/osc_receiver.py
+++ b/pybinsim/osc_receiver.py
@@ -59,7 +59,6 @@ class OscReceiver(PkgReceiver):
         osc_dispatcher_ds.map("/pyBinSim_ds_Filter_sourceOrientation", self.handle_ds_filter_input)
         osc_dispatcher_ds.map("/pyBinSim_ds_Filter_sourcePosition", self.handle_ds_filter_input)
 
-
         osc_dispatcher_early = dispatcher.Dispatcher()
         osc_dispatcher_early.map("/pyBinSim_early_Filter", self.handle_early_filter_input)
         osc_dispatcher_early.map("/pyBinSim_early_Filter_Short", self.handle_early_filter_input)
@@ -84,6 +83,7 @@ class OscReceiver(PkgReceiver):
         osc_dispatcher_misc.map("/pyBinSimPauseConvolution", self.handle_convolution_pause)
         osc_dispatcher_misc.map("/pyBinSim_sd_Filter", self.handle_sd_filter_input)
         osc_dispatcher_misc.map("/pyBinSimLoudness", self.handle_loudness)
+        osc_dispatcher_misc.map("/pyBinSimDistance", self.handle_distance)
         osc_dispatcher_misc.map("/pyBinSimPlay", self.handle_play)
         osc_dispatcher_misc.map("/pyBinSimPlayerControl", self.handle_player_control)
         osc_dispatcher_misc.map("/pyBinSimPlayerChannel", self.handle_player_channel)
@@ -140,5 +140,3 @@ class OscReceiver(PkgReceiver):
         self.server2.shutdown()
         self.server3.shutdown()
         self.server4.shutdown()
-
-    

--- a/pybinsim/pkg_receiver.py
+++ b/pybinsim/pkg_receiver.py
@@ -141,7 +141,7 @@ class PkgReceiver(object):
         if len(args) == len(self.valueList_late_filter[current_channel, key_slice]):
 
             if all(args == self.valueList_late_filter[current_channel, key_slice]):
-                self.log.debug("Same late  filter as before")
+                self.log.debug("Same late filter as before")
             else:
                 self.late_filters_updated[current_channel] = True
                 self.valueList_late_filter[current_channel, key_slice] = args
@@ -284,6 +284,13 @@ class PkgReceiver(object):
 
         self.currentConfig.set('loudnessFactor', float(value))
         self.log.info("Changing loudness")
+    
+    def handle_distance(self, identifier, value):
+        """ Handler for distance control"""
+        assert identifier == "/pyBinSimDistance"
+
+        self.currentConfig.set('distanceFactor', float(value))
+        # self.log.info(f"Distance Factor set to: {value}")
 
     def is_ds_filter_update_necessary(self, channel):
         """ Check if there is a new direct filter for channel """

--- a/pybinsim/zmq_receiver.py
+++ b/pybinsim/zmq_receiver.py
@@ -61,6 +61,8 @@ class ZmqReceiver(PkgReceiver):
             "/pyBinSim_late_Filter_Custom": self.handle_late_filter_input,
             # source directivity
             "/pyBinSim_sd_Filter": self.handle_sd_filter_input,
+            # distance factor
+            "pyBinSimDistance": self.handle_distance,
             # other
             "/pyBinSimFile": self.handle_file_input,
             "/pyBinSimPlay": self.handle_play,


### PR DESCRIPTION
The update introduces an interface to apply a distance factor to the direct sound pipeline while leaving the other pipelines unaltered. It multiplies the incoming float from /pyBinSimDistance with the DS buffer.

Seems particularly helpful for simulating listener translation without adding additional degrees to the filter map. Consequently offers the advantage of largely reduced RAM usage with larger grids.